### PR TITLE
Adjust cgprofile format to: fromSymbol toSymbol count

### DIFF
--- a/create_lld_profile.cc
+++ b/create_lld_profile.cc
@@ -37,8 +37,8 @@ struct LLDProfileBuilder : SymbolTraverser {
   void Visit(const Symbol *node) {
     for (const auto &pos_count : node->pos_counts)
       for (const auto &target_count : pos_count.second.target_map)
-        os << target_count.second << ' ' << node->name() << ' '
-           << target_count.first << '\n';
+        os << node->name() << ' ' << target_count.first
+           << ' ' << target_count.second << '\n';
   }
 
   void Start(const SymbolMap &symbol_map) {


### PR DESCRIPTION
Adjust the output format, since latest C3 implementation expects "fromSym toSym count"
see@ https://github.com/llvm-mirror/lld/commit/220cceb70797b471f06d089f3fea41b458927de6#diff-e085f6cef59481fa64d1f46277563d0c